### PR TITLE
Cache player heads on player login

### DIFF
--- a/src/main/java/net/minso/chathead/listener/PlayerListener.java
+++ b/src/main/java/net/minso/chathead/listener/PlayerListener.java
@@ -14,6 +14,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerLoginEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 
 public class PlayerListener implements Listener {
@@ -25,6 +26,11 @@ public class PlayerListener implements Listener {
         if (!Bukkit.getServer().getOnlineMode() && plugin.getPluginConfig().getServerOnlineMode())
             Bukkit.getLogger().warning(" CHATHEAD - Server is currently in OFFLINE MODE! Change online-mode in the config!");
 
+    }
+
+    @EventHandler
+    public void onPlayerLogin(PlayerLoginEvent event) {
+        ChatHeadAPI.getInstance().getHead(event.getPlayer());
     }
 
     @EventHandler


### PR DESCRIPTION
Right now, player heads are cached _after_ a request is performed, so the first request is always an empty component. This PR fixes this by performing a simple API call upon a player's login.