### PR TITLE
Fix offline mode support

### DIFF
--- a/ChatHead.iml
+++ b/ChatHead.iml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="FacetManager">
+    <facet type="minecraft" name="Minecraft">
+      <configuration>
+        <autoDetectTypes>
+          <platformType>SPIGOT</platformType>
+          <platformType>ADVENTURE</platformType>
+        </autoDetectTypes>
+        <projectReimportVersion>1</projectReimportVersion>
+      </configuration>
+    </facet>
+  </component>
+</module>

--- a/src/main/java/net/minso/chathead/API/ChatHeadAPI.java
+++ b/src/main/java/net/minso/chathead/API/ChatHeadAPI.java
@@ -6,9 +6,9 @@ import net.minso.chathead.API.impl.CrafatarSource;
 import net.minso.chathead.API.impl.McHeadsSource;
 import net.minso.chathead.API.impl.MinotarSource;
 import net.minso.chathead.API.impl.MojangSource;
+import net.minso.chathead.Main;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
-import org.bukkit.plugin.java.JavaPlugin;
 
 import java.util.UUID;
 
@@ -39,15 +39,15 @@ public class ChatHeadAPI {
 
     private static ChatHeadAPI instance;
 
-    private final JavaPlugin plugin;
+    private final Main plugin;
     private final HeadCache headCache;
 
     /**
      * Constructs a new {@code ChatHeadAPI} instance.
      *
-     * @param plugin the {@link JavaPlugin} instance associated with this API.
+     * @param plugin the {@link Main} instance associated with this API.
      */
-    public ChatHeadAPI(JavaPlugin plugin) {
+    public ChatHeadAPI(Main plugin) {
         this.plugin = plugin;
         this.headCache = new HeadCache(plugin);
     }
@@ -56,7 +56,7 @@ public class ChatHeadAPI {
      * Retrieves the singleton instance of the {@code ChatHeadAPI}.
      *
      * @return the singleton instance of {@code ChatHeadAPI}.
-     * @throws IllegalArgumentException if {@code ChatHeadAPI} has not been initialized via {@link #initialize(JavaPlugin)}.
+     * @throws IllegalArgumentException if {@code ChatHeadAPI} has not been initialized via {@link #initialize(Main)}.
      */
     public static ChatHeadAPI getInstance() {
         if (instance == null) {
@@ -66,26 +66,26 @@ public class ChatHeadAPI {
     }
 
     /**
-     * Initializes the {@code ChatHeadAPI} with the provided {@link JavaPlugin} instance.
+     * Initializes the {@code ChatHeadAPI} with the provided {@link Main} instance.
      * <p>
      * This method reads the "skin-source" configuration from the plugin's configuration file,
      * sets the default skin source accordingly, and creates the singleton instance. If the API is
      * already initialized, an {@link IllegalStateException} is thrown.
      * </p>
      *
-     * @param plugin the {@link JavaPlugin} instance to associate with the {@code ChatHeadAPI}.
+     * @param plugin the {@link Main} instance to associate with the {@code ChatHeadAPI}.
      * @throws IllegalStateException if {@code ChatHeadAPI} has already been initialized.
      */
-    public static void initialize(JavaPlugin plugin) {
+    public static void initialize(Main plugin) {
         if (instance != null) {
             throw new IllegalStateException("PlayerHeadAPI has already been initialized.");
         }
 
         String skinSourceConfig = plugin.getConfig().getString("skin-source", "MOJANG");
         defaultSource = switch (skinSourceConfig.toUpperCase()) {
-            case "CRAFATAR" -> new CrafatarSource();
-            case "MINOTAR" -> new MinotarSource();
-            case "MCHEADS" -> new McHeadsSource();
+            case "CRAFATAR" -> new CrafatarSource(plugin.isOfflineModeEnabled());
+            case "MINOTAR" -> new MinotarSource(plugin.isOfflineModeEnabled());
+            case "MCHEADS" -> new McHeadsSource(plugin.isOfflineModeEnabled());
             default -> new MojangSource();
         };
 

--- a/src/main/java/net/minso/chathead/API/HeadCache.java
+++ b/src/main/java/net/minso/chathead/API/HeadCache.java
@@ -1,6 +1,7 @@
 package net.minso.chathead.API;
 
 import net.md_5.bungee.api.chat.BaseComponent;
+import net.minso.chathead.Main;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -22,9 +23,9 @@ import java.util.concurrent.ConcurrentHashMap;
 public class HeadCache {
 
     /**
-     * The {@link JavaPlugin} instance associated with this cache.
+     * The {@link Main} instance associated with this cache.
      */
-    private final JavaPlugin plugin;
+    private final Main plugin;
 
     /**
      * The expiration time for cache entries in milliseconds (5 minutes).
@@ -55,7 +56,7 @@ public class HeadCache {
      *
      * @param plugin the {@link JavaPlugin} instance associated with this cache.
      */
-    public HeadCache(JavaPlugin plugin) {
+    public HeadCache(Main plugin) {
         this.plugin = plugin;
         startCacheCleanupTask();
     }

--- a/src/main/java/net/minso/chathead/Main.java
+++ b/src/main/java/net/minso/chathead/Main.java
@@ -10,6 +10,10 @@ import net.minso.chathead.listener.PlayerListener;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.NotNull;
 
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Properties;
+
 public final class Main extends JavaPlugin {
     public static final String RESOURCE_PACK = "https://github.com/OGminso/ChatHeadFont/raw/main/pack.zip";
     private Config config;
@@ -38,6 +42,17 @@ public final class Main extends JavaPlugin {
 
     private void registerListeners() {
         getServer().getPluginManager().registerEvents(new PlayerListener(this), this);
+    }
+
+    public boolean isOfflineModeEnabled() {
+        try {
+            Properties props = new Properties();
+            props.load(new FileInputStream("server.properties"));
+
+            return Boolean.parseBoolean(props.getProperty("online-mode", "true"));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @NotNull

--- a/src/main/java/net/minso/chathead/config/Config.java
+++ b/src/main/java/net/minso/chathead/config/Config.java
@@ -18,10 +18,6 @@ public class Config {
         return plugin.getConfig().getBoolean("auto-download-pack", true);
     }
 
-    public boolean getServerOnlineMode() {
-        return plugin.getConfig().getBoolean("online-mode", true);
-    }
-
     public boolean getSkinOverlayEnabled() {
         return plugin.getConfig().getBoolean("enable-skin-overlay", true);
     }
@@ -51,7 +47,6 @@ public class Config {
         //default configuration:
         config.addDefault("skin-source", "MOJANG");
         config.addDefault("auto-download-pack", true);
-        config.addDefault("online-mode", true);
         config.addDefault("enable-skin-overlay", true);
         config.addDefault("enable-join-messages", true);
         config.addDefault("enable-leave-messages", true);


### PR DESCRIPTION
While [this pull request](https://github.com/OGminso/ChatHeadFont/pull/5) add offline server support, it still doesn't work as `useUUIDWhenRetrieve` is always true in every API implements no matter `offline-mode` in the config is set to `true` or `false`.

In this push request, I remove completely `offline-mode` option from the config, as it's unnecessary since we can read directly from `server.properties`. Moreover, I make this option actually working by checking offline mode and put into `useUUIDWhenRetrieve`. Now it works like a charm :D

This is an example in my own server:
![{36AE01BA-BC14-40EA-B9F9-2A28C5494D34}](https://github.com/user-attachments/assets/2b6c1347-c6d1-4065-a74b-7d8cf711ca9f)
